### PR TITLE
chore(travis): remove custom image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
-sudo: required
-dist: trusty
 language: node_js
 node_js:
 - "7"
-
-addons:
-  firefox: "50.0"
 
 cache:
   directories:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@
 module.exports = function (config) {
     config.set({
 
-        frameworks: ["karma-typescript", "jasmine"],
+        frameworks: ["karma-typescript", "es6-shim", "jasmine"],
 
         files: [
             {pattern: "src/**/*.ts"}
@@ -41,7 +41,7 @@ module.exports = function (config) {
         },
 
         browsers: process.env.TRAVIS
-            ? ['Firefox', 'Chrome']
+            ? ['Firefox', 'ChromeTravis']
             : ['Firefox', 'Chrome'],
 
         // enable / disable colors in the output (reporters and logs)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jasmine-core": "^2.5.2",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-es6-shim": "^1.0.0",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "^1.1.0",
     "karma-typescript": "^2.1.6",


### PR DESCRIPTION
use travis' default container based image with default firefox having es6-shim
Closes #4 