### PR TITLE
chore(ts): fix typescript module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "module": "es6",
+    "module": "commonjs",
     "esModuleInterop": true,
     "lib": ["es5", "scripthost", "dom", "es6"],
     "noImplicitAny": true,


### PR DESCRIPTION
long time ago there was a commit on this file:

https://github.com/crazyfactory/ts-module-boilerplate/commit/c2e31dd18be5829c1786164df38f9d805db57084#diff-e5e546dd2eb0351f813d63d1b39dbc48

there we changed from commonjs to es6, we already have es2015 tsconfig and they're producing almost same exports

I checked my node_modules, and every package I looked at is exporting using module.exports

right now our lib and lib.2015 has almost no difference, (there is a it I think, but not in terms of exports)

applying this patch will mean we'll be publishing both version, and people can choose which one they want to import :slightly_smiling_face: 

@paibamboo any comments?