### PR TITLE
chore(git): enable team shared runConfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .vscode/
 .idea/
 
+!.idea/runConfigurations/
+
 # builds
 lib/
 lib.es2015/


### PR DESCRIPTION
when we create configuration, intellij allows us to check a box which says "share with team", right now it's ignored, let's track if someone wants to commit it.